### PR TITLE
fix  : 회원가입,로그인 코드 수정 

### DIFF
--- a/src/main/java/io/reviewcoder/ReviewCoderApiApplication.java
+++ b/src/main/java/io/reviewcoder/ReviewCoderApiApplication.java
@@ -8,7 +8,7 @@ public class ReviewCoderApiApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(ReviewCoderApiApplication.class, args);
-
+		System.out.println("gggggggggggggggggggggggg");
 	}
 
 }

--- a/src/main/java/io/reviewcoder/domain/user/controller/AuthController.java
+++ b/src/main/java/io/reviewcoder/domain/user/controller/AuthController.java
@@ -35,19 +35,12 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@Valid @RequestBody SignUpRequest req) {
-        // 이메일 인증 여부 확인
-        if (!emailCodeService.isVerified(req.email())) {
-            return ResponseEntity.badRequest().body(Map.of("error", "이메일이 인증되지 않았습니다. 인증 후 다시 시도해주세요."));
+    public ResponseEntity<?> signup(@RequestBody SignUpRequest req) {
+        try {
+            userService.registerUser(req.email(), req.password());
+            return ResponseEntity.ok(Map.of("message", "회원가입 성공"));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
-
-        // 중복 체크
-        if (userService.existsByEmail(req.email())) {
-            return ResponseEntity.badRequest().body(Map.of("error", "이미 사용 중인 이메일입니다."));
-        }
-
-        userService.createUser(req.email(), passwordEncoder.encode(req.password()));
-
-        return ResponseEntity.ok(Map.of("message", "회원가입이 완료되었습니다."));
     }
 }

--- a/src/main/java/io/reviewcoder/domain/user/controller/AuthController.java
+++ b/src/main/java/io/reviewcoder/domain/user/controller/AuthController.java
@@ -1,0 +1,53 @@
+package io.reviewcoder.domain.user.controller;
+
+import io.reviewcoder.domain.user.dto.*;
+import io.reviewcoder.domain.user.service.*;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final UserService userService;
+    private final EmailCodeService emailCodeService;
+    private final PasswordEncoder passwordEncoder;
+
+    // 이메일 인증 코드 발송
+    @PostMapping("/email/send")
+    public ResponseEntity<?> sendCode(@RequestParam String email) {
+        emailCodeService.send(email); // TTL 5분
+        return ResponseEntity.ok(Map.of("message", "code sent"));
+    }
+
+    // 이메일 인증 코드 검증
+    @PostMapping("/email/verify")
+    public ResponseEntity<?> verify(@RequestParam String email, @RequestParam String code) {
+        boolean ok = emailCodeService.verify(email, code);
+        if (!ok) return ResponseEntity.badRequest().body(Map.of("error", "INVALID_CODE"));
+        return ResponseEntity.ok(Map.of("message", "verified"));
+    }
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@Valid @RequestBody SignUpRequest req) {
+        // 이메일 인증 여부 확인
+        if (!emailCodeService.isVerified(req.email())) {
+            return ResponseEntity.badRequest().body(Map.of("error", "이메일이 인증되지 않았습니다. 인증 후 다시 시도해주세요."));
+        }
+
+        // 중복 체크
+        if (userService.existsByEmail(req.email())) {
+            return ResponseEntity.badRequest().body(Map.of("error", "이미 사용 중인 이메일입니다."));
+        }
+
+        userService.createUser(req.email(), passwordEncoder.encode(req.password()));
+
+        return ResponseEntity.ok(Map.of("message", "회원가입이 완료되었습니다."));
+    }
+}

--- a/src/main/java/io/reviewcoder/domain/user/dto/SignUpRequest.java
+++ b/src/main/java/io/reviewcoder/domain/user/dto/SignUpRequest.java
@@ -1,0 +1,11 @@
+package io.reviewcoder.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+        @Email @NotBlank String email,
+        @NotBlank @Size(min = 8, max = 64)
+        String password) {
+}

--- a/src/main/java/io/reviewcoder/domain/user/model/User.java
+++ b/src/main/java/io/reviewcoder/domain/user/model/User.java
@@ -1,0 +1,39 @@
+package io.reviewcoder.domain.user.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+
+    // 이메일 인증을 위해서 컬럼 추가
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "email_verified_at")
+    private LocalDateTime emailVerifiedAt;
+}

--- a/src/main/java/io/reviewcoder/domain/user/model/User.java
+++ b/src/main/java/io/reviewcoder/domain/user/model/User.java
@@ -29,11 +29,6 @@ public class User {
     @Column(name = "updated_at", insertable = false, updatable = false)
     private LocalDateTime updatedAt;
 
-
-    // 이메일 인증을 위해서 컬럼 추가
-    @Column(name = "email_verified", nullable = false)
-    private boolean emailVerified;
-
     @Column(name = "email_verified_at")
     private LocalDateTime emailVerifiedAt;
 }

--- a/src/main/java/io/reviewcoder/domain/user/repository/UserRepository.java
+++ b/src/main/java/io/reviewcoder/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package io.reviewcoder.domain.user.repository;
+
+import io.reviewcoder.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/io/reviewcoder/domain/user/service/EmailCodeService.java
+++ b/src/main/java/io/reviewcoder/domain/user/service/EmailCodeService.java
@@ -11,13 +11,21 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class EmailCodeService {
     private final MailService mailService;
-    private final StringRedisTemplate redis;
+    private final StringRedisTemplate redisTemplate;
     private final Random random = new Random();
 
     // 키 규칙
-    private String codeKey(String email) { return "email:code:" + email; }
-    private String verifiedKey(String email) { return "email:verified:" + email; }
-    private String cooldownKey(String email) { return "email:cooldown:" + email; }
+    private String codeKey(String email) {
+        return "email:code:" + email;
+    }
+
+    private String verifiedKey(String email) {
+        return "email:verified:" + email;
+    }
+
+    private String cooldownKey(String email) {
+        return "email:cooldown:" + email;
+    }
 
     // 설정값
     private static final Duration CODE_TTL = Duration.ofMinutes(5);
@@ -25,30 +33,30 @@ public class EmailCodeService {
     private static final Duration COOLDOWN_TTL = Duration.ofSeconds(30);
 
     public void send(String email) {
-        if (Boolean.TRUE.equals(redis.hasKey(cooldownKey(email)))) {
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(cooldownKey(email)))) {
             throw new IllegalStateException("TOO_FREQUENT_REQUEST");
         }
         String code = String.format("%06d", random.nextInt(1_000_000));
 
         // Redis 저장
-        redis.opsForValue().set(codeKey(email), code, CODE_TTL);
-        redis.opsForValue().set(cooldownKey(email), "1", COOLDOWN_TTL);
+        redisTemplate.opsForValue().set(codeKey(email), code, CODE_TTL);
+        redisTemplate.opsForValue().set(cooldownKey(email), "1", COOLDOWN_TTL);
 
         mailService.sendCodeMail(email, code);
     }
-    
+
     //코드검증
     public boolean verify(String email, String code) {
-        String saved = redis.opsForValue().get(codeKey(email));
+        String saved = redisTemplate.opsForValue().get(codeKey(email));
         if (saved == null || !saved.equals(code)) return false;
-        
-        redis.opsForValue().set(verifiedKey(email), "1", VERIFIED_TTL);
-        redis.delete(codeKey(email));
+
+        redisTemplate.opsForValue().set(verifiedKey(email), "1", VERIFIED_TTL);
+        redisTemplate.delete(codeKey(email));
         return true;
     }
 
     //인증완료한 이메일인지 확인
     public boolean isVerified(String email) {
-        return Boolean.TRUE.equals(redis.hasKey(verifiedKey(email)));
+        return Boolean.TRUE.equals(redisTemplate.hasKey(verifiedKey(email)));
     }
 }

--- a/src/main/java/io/reviewcoder/domain/user/service/EmailCodeService.java
+++ b/src/main/java/io/reviewcoder/domain/user/service/EmailCodeService.java
@@ -1,0 +1,54 @@
+package io.reviewcoder.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailCodeService {
+    private final MailService mailService;
+    private final StringRedisTemplate redis;
+    private final Random random = new Random();
+
+    // 키 규칙
+    private String codeKey(String email) { return "email:code:" + email; }
+    private String verifiedKey(String email) { return "email:verified:" + email; }
+    private String cooldownKey(String email) { return "email:cooldown:" + email; }
+
+    // 설정값
+    private static final Duration CODE_TTL = Duration.ofMinutes(5);
+    private static final Duration VERIFIED_TTL = Duration.ofMinutes(10);
+    private static final Duration COOLDOWN_TTL = Duration.ofSeconds(30);
+
+    public void send(String email) {
+        if (Boolean.TRUE.equals(redis.hasKey(cooldownKey(email)))) {
+            throw new IllegalStateException("TOO_FREQUENT_REQUEST");
+        }
+        String code = String.format("%06d", random.nextInt(1_000_000));
+
+        // Redis 저장
+        redis.opsForValue().set(codeKey(email), code, CODE_TTL);
+        redis.opsForValue().set(cooldownKey(email), "1", COOLDOWN_TTL);
+
+        mailService.sendCodeMail(email, code);
+    }
+    
+    //코드검증
+    public boolean verify(String email, String code) {
+        String saved = redis.opsForValue().get(codeKey(email));
+        if (saved == null || !saved.equals(code)) return false;
+        
+        redis.opsForValue().set(verifiedKey(email), "1", VERIFIED_TTL);
+        redis.delete(codeKey(email));
+        return true;
+    }
+
+    //인증완료한 이메일인지 확인
+    public boolean isVerified(String email) {
+        return Boolean.TRUE.equals(redis.hasKey(verifiedKey(email)));
+    }
+}

--- a/src/main/java/io/reviewcoder/domain/user/service/MailService.java
+++ b/src/main/java/io/reviewcoder/domain/user/service/MailService.java
@@ -1,0 +1,28 @@
+package io.reviewcoder.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendCodeMail(String to, String code) {
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(to);
+        msg.setSubject("[reviewcoder] 이메일 인증 코드");
+        msg.setText("""
+                안녕하세요.
+                아래 인증 코드를 입력해주세요.
+
+                인증 코드: %s
+
+                (유효시간: 5분)
+                """.formatted(code));
+        mailSender.send(msg);
+    }
+}

--- a/src/main/java/io/reviewcoder/domain/user/service/UserService.java
+++ b/src/main/java/io/reviewcoder/domain/user/service/UserService.java
@@ -1,0 +1,30 @@
+package io.reviewcoder.domain.user.service;
+
+import io.reviewcoder.domain.user.model.User;
+import io.reviewcoder.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Transactional
+    public Long createUser(String email, String encodedPassword) {
+        User user = new User();
+        user.setEmail(email);
+        user.setPasswordHash(encodedPassword);
+        user = userRepository.save(user);
+        return user.getId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,55 @@
+spring:
+  application:
+    name: reviewcoder
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/reviewcoder?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    username: root
+    password: a1346798
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate   # Flyway 사용 → 스키마 자동생성 안 함
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    open-in-view: false
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  mail:   # (선택: 이메일 인증/알림에 사용)
+    host: smtp.example.com
+    port: 587
+    username: polcho1221@gmail.com
+    password: !Aa134679852
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+jwt:
+  secret: ${JWT_SECRET:change-me}   # 환경변수로 관리 권장
+  access-exp-min: 60
+  refresh-exp-days: 7
+
+aws:   # (선택: 첨부파일 S3)
+  s3:
+    bucket: your-bucket
+    region: ap-northeast-2
+
+server:
+  port: 8080
+  error:
+    include-message: always
+    include-binding-errors: always


### PR DESCRIPTION
AS-IS
이메일 인증 상태를 email_verified(boolean)로 중복 관리
회원가입 로직 일부가 AuthController에 존재 (검증/중복체크/생성 분산)
System.out.println("ggg...")로 의미 없는 콘솔 출력
TO-BE
ERD/엔티티 정리:
email_verified 컬럼 삭제
email_verified_at TIMESTAMP NULL만 유지하고 인증 완료 시점 기록
비즈니스 로직 서비스 레이어로 이관:
UserService.registerUser(email, rawPassword)에서
System.out.println 제거, @Slf4j 사용
ApplicationReadyEvent에서 “서버가 실행되었습니다.” INFO 로그 출력
테스트
 테스트 코드

 API 테스트
[POST] /api/v1/auth/email/send → 메일 전송 성공

[POST] /api/v1/auth/email/verify?email={email}&code={code} → verified 응답 확인

[POST] /api/v1/auth/signup

미인증 이메일 → 400 (이메일 인증 필요)

인증된 이메일 + 신규 → 200, 가입 성공

이미 존재하는 이메일 → 400 (이미 사용 중인 이메일)