### PR TITLE
feat : 학습기록 설계 구현

### DIFF
--- a/src/main/java/io/reviewcoder/domain/problem/controller/ProblemController.java
+++ b/src/main/java/io/reviewcoder/domain/problem/controller/ProblemController.java
@@ -5,7 +5,7 @@ import io.reviewcoder.domain.problem.dto.ProblemCreateRequest;
 import io.reviewcoder.domain.problem.dto.ProblemResponse;
 import io.reviewcoder.domain.problem.dto.ProblemUpdateRequest;
 import io.reviewcoder.domain.problem.service.ProblemService;
-import io.reviewcoder.global.auth.CurrentUser;
+import io.reviewcoder.global.auth.CurrentUserProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,7 +23,7 @@ import java.security.Principal;
 public class ProblemController {
 
     private final ProblemService service;
-    private final CurrentUser currentUser;
+    private final CurrentUserProvider currentUser;
 
     // 생성
     @PostMapping

--- a/src/main/java/io/reviewcoder/domain/problem/dto/ProblemCreateRequest.java
+++ b/src/main/java/io/reviewcoder/domain/problem/dto/ProblemCreateRequest.java
@@ -1,6 +1,8 @@
 package io.reviewcoder.domain.problem.dto;
 
+import io.reviewcoder.domain.problem.model.Problem;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,13 +25,11 @@ public class ProblemCreateRequest {
     @Size(max = 1000)
     private String sourceUrl;
 
-    @NotBlank
-    @Size(max = 16)
-    private String difficulty; // "E" | "M" | "H"
+    @NotNull
+    private Problem.Difficulty difficulty;   // E | M | H
 
-    @NotBlank
-    @Size(max = 20)
-    private String status; // "UNSOLVED" | "SOLVED" | "REVIEW_NEEDED"
+    @NotNull
+    private Problem.ProblemStatus status;    // UNSOLVED | SOLVED | REVIEW_NEEDED
 
     private String memo;
 

--- a/src/main/java/io/reviewcoder/domain/problem/dto/ProblemUpdateRequest.java
+++ b/src/main/java/io/reviewcoder/domain/problem/dto/ProblemUpdateRequest.java
@@ -1,6 +1,7 @@
 package io.reviewcoder.domain.problem.dto;
 
 
+import io.reviewcoder.domain.problem.model.Problem;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -19,14 +20,13 @@ public class ProblemUpdateRequest {
     @Size(max = 1000)
     private String sourceUrl;
 
-    @Size(max = 16)
-    private String difficulty; // "E" | "M" | "H"
+    private Problem.Difficulty difficulty;       
 
-    @Size(max = 20)
-    private String status; // "UNSOLVED" | "SOLVED" | "REVIEW_NEEDED"
+    private Problem.ProblemStatus status;
 
     private String memo;
 
+    @Size(max = 500)
     private String tag;
 
     private LocalDateTime nextReviewAt;

--- a/src/main/java/io/reviewcoder/domain/problem/model/Problem.java
+++ b/src/main/java/io/reviewcoder/domain/problem/model/Problem.java
@@ -34,12 +34,17 @@ public class Problem {
     @Column(name = "source_url", length = 1000)
     private String sourceUrl;
 
-    // ENUM 대신 문자열(간단 버전)
-    @Column(length = 16, nullable = false)
-    private String difficulty; // "E" | "M" | "H"
+    // --- Enums ---
+    public enum Difficulty { E, M, H }
+    public enum ProblemStatus { UNSOLVED, SOLVED, REVIEW_NEEDED }
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16, nullable = false)
+    private Difficulty difficulty;
+
+    @Enumerated(EnumType.STRING)
     @Column(length = 20, nullable = false)
-    private String status; // "UNSOLVED" | "SOLVED" | "REVIEW_NEEDED"
+    private ProblemStatus status;
 
     @Column(name = "memo", columnDefinition = "text")
     private String memo;

--- a/src/main/java/io/reviewcoder/domain/problem/service/ProblemService.java
+++ b/src/main/java/io/reviewcoder/domain/problem/service/ProblemService.java
@@ -1,12 +1,11 @@
 package io.reviewcoder.domain.problem.service;
 
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.reviewcoder.domain.problem.dto.ProblemCreateRequest;
 import io.reviewcoder.domain.problem.dto.ProblemResponse;
 import io.reviewcoder.domain.problem.dto.ProblemUpdateRequest;
 import io.reviewcoder.domain.problem.model.Problem;
 import io.reviewcoder.domain.problem.repository.ProblemRepository;
+import io.reviewcoder.domain.problem.util.TagUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,8 +26,8 @@ public class ProblemService {
                 .userId(p.getUserId())
                 .title(p.getTitle())
                 .sourceUrl(p.getSourceUrl())
-                .difficulty(p.getDifficulty())
-                .status(p.getStatus())
+                .difficulty(p.getDifficulty().name())
+                .status(p.getStatus().name())
                 .memo(p.getMemo())
                 .bookmarked(p.isBookmarked())
                 .nextReviewAt(p.getNextReviewAt())
@@ -50,7 +49,7 @@ public class ProblemService {
                 .memo(req.getMemo())
                 .bookmarked(false)
                 .nextReviewAt(req.getNextReviewAt())
-                .tag(normalizeTag(req.getTag()))
+                .tag(TagUtils.normalize(req.getTag()))
                 .build();
         repository.save(p);
         return toResponse(p);
@@ -86,7 +85,7 @@ public class ProblemService {
         if (req.getDifficulty() != null) p.setDifficulty(req.getDifficulty());
         if (req.getStatus() != null)     p.setStatus(req.getStatus());
         if (req.getMemo() != null)       p.setMemo(req.getMemo());
-        if (req.getTag() != null)        p.setTag(normalizeTag(req.getTag())); // "" -> null
+        if (req.getTag() != null) p.setTag(TagUtils.normalize(req.getTag()));
         p.setNextReviewAt(req.getNextReviewAt()); // null 허용
 
         return toResponse(p);
@@ -118,10 +117,4 @@ public class ProblemService {
                 .map(this::toResponse);
     }
 
-    // --- 유틸 ---
-    private String normalizeTag(String tag) {
-        if (tag == null) return null;
-        String t = tag.trim();
-        return t.isEmpty() ? null : t;
-    }
 }

--- a/src/main/java/io/reviewcoder/domain/problem/util/TagUtils.java
+++ b/src/main/java/io/reviewcoder/domain/problem/util/TagUtils.java
@@ -1,0 +1,15 @@
+package io.reviewcoder.domain.problem.util;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TagUtils {
+
+    public static String normalize(String tag) {
+        if (tag == null) return null;
+        String t = tag.trim();
+        return t.isEmpty() ? null : t;
+    }
+}

--- a/src/main/java/io/reviewcoder/domain/record/controller/RecordController.java
+++ b/src/main/java/io/reviewcoder/domain/record/controller/RecordController.java
@@ -1,0 +1,61 @@
+package io.reviewcoder.domain.record.controller;
+
+import io.reviewcoder.domain.record.dto.*;
+import io.reviewcoder.domain.record.service.RecordService;
+import io.reviewcoder.global.auth.CurrentUserProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class RecordController {
+
+    private final RecordService service;
+    private final CurrentUserProvider currentUser;
+
+    @PostMapping("/records")
+    public ResponseEntity<RecordResponse> create(Principal principal,
+                                                 @Valid @RequestBody RecordCreateRequest req) {
+        Long userId = currentUser.id(principal);
+        return ResponseEntity.ok(service.create(userId, req));
+    }
+
+    @GetMapping("/problems/{problemId}/records")
+    public ResponseEntity<Page<RecordResponse>> listByProblem(Principal principal,
+                                                              @PathVariable Long problemId,
+                                                              @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+        Long userId = currentUser.id(principal);
+        return ResponseEntity.ok(service.listByProblem(userId, problemId, pageable));
+    }
+
+    @GetMapping("/records/{recordId}")
+    public ResponseEntity<RecordResponse> getOne(Principal principal,
+                                                 @PathVariable Long recordId) {
+        Long userId = currentUser.id(principal);
+        return ResponseEntity.ok(service.getOne(userId, recordId));
+    }
+
+    @PatchMapping("/records/{recordId}")
+    public ResponseEntity<RecordResponse> update(Principal principal,
+                                                 @PathVariable Long recordId,
+                                                 @Valid @RequestBody RecordUpdateRequest req) {
+        Long userId = currentUser.id(principal);
+        return ResponseEntity.ok(service.update(userId, recordId, req));
+    }
+
+    @DeleteMapping("/records/{recordId}")
+    public ResponseEntity<Void> delete(Principal principal,
+                                       @PathVariable Long recordId) {
+        Long userId = currentUser.id(principal);
+        service.delete(userId, recordId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/io/reviewcoder/domain/record/dto/RecordCreateRequest.java
+++ b/src/main/java/io/reviewcoder/domain/record/dto/RecordCreateRequest.java
@@ -1,0 +1,23 @@
+package io.reviewcoder.domain.record.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordCreateRequest {
+
+    @NotNull
+    private Long problemId;
+
+    @Size(max = 300)
+    private String titleOpt;
+
+    @NotBlank
+    @Size(max = 20000)
+    private String contentMarkdown;
+}

--- a/src/main/java/io/reviewcoder/domain/record/dto/RecordResponse.java
+++ b/src/main/java/io/reviewcoder/domain/record/dto/RecordResponse.java
@@ -1,0 +1,18 @@
+package io.reviewcoder.domain.record.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecordResponse {
+    private final Long id;
+    private final Long userId;
+    private final Long problemId;
+    private final String titleOpt;
+    private final String contentMarkdown;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+}

--- a/src/main/java/io/reviewcoder/domain/record/dto/RecordUpdateRequest.java
+++ b/src/main/java/io/reviewcoder/domain/record/dto/RecordUpdateRequest.java
@@ -1,0 +1,17 @@
+package io.reviewcoder.domain.record.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordUpdateRequest {
+
+    @Size(max = 300)
+    private String titleOpt;
+
+    @Size(max = 20000)
+    private String contentMarkdown;
+}

--- a/src/main/java/io/reviewcoder/domain/record/model/StudyRecord.java
+++ b/src/main/java/io/reviewcoder/domain/record/model/StudyRecord.java
@@ -1,0 +1,44 @@
+package io.reviewcoder.domain.record.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "study_record",
+        indexes = {
+                @Index(name = "idx_record_user_problem", columnList = "user_id,problem_id"),
+                @Index(name = "idx_record_problem_created", columnList = "problem_id,created_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudyRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "problem_id", nullable = false)
+    private Long problemId;
+
+    @Column(name = "title_opt", length = 300)
+    private String titleOpt;
+
+    @Column(name = "content_markdown", columnDefinition = "mediumtext")
+    private String contentMarkdown; //
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/io/reviewcoder/domain/record/repository/RecordRepository.java
+++ b/src/main/java/io/reviewcoder/domain/record/repository/RecordRepository.java
@@ -1,0 +1,17 @@
+package io.reviewcoder.domain.record.repository;
+
+import io.reviewcoder.domain.record.model.StudyRecord;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecordRepository extends JpaRepository<StudyRecord, Long> {
+
+    // 문제별 타임라인(내 기록만)
+    Page<StudyRecord> findByUserIdAndProblemId(Long userId, Long problemId, Pageable pageable);
+
+    // 소유자 검증 단건 조회
+    Optional<StudyRecord> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/io/reviewcoder/domain/record/service/RecordService.java
+++ b/src/main/java/io/reviewcoder/domain/record/service/RecordService.java
@@ -1,0 +1,89 @@
+package io.reviewcoder.domain.record.service;
+import io.reviewcoder.domain.record.dto.RecordCreateRequest;
+import io.reviewcoder.domain.record.dto.RecordResponse;
+import io.reviewcoder.domain.record.dto.RecordUpdateRequest;
+import io.reviewcoder.domain.record.model.StudyRecord;
+import io.reviewcoder.domain.record.repository.RecordRepository;
+import io.reviewcoder.domain.problem.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class RecordService {
+
+    private final RecordRepository recordRepository;
+    private final ProblemRepository problemRepository;
+
+    private RecordResponse toResponse(StudyRecord r) {
+        return RecordResponse.builder()
+                .id(r.getId())
+                .userId(r.getUserId())
+                .problemId(r.getProblemId())
+                .titleOpt(r.getTitleOpt())
+                .contentMarkdown(r.getContentMarkdown())
+                .createdAt(r.getCreatedAt())
+                .updatedAt(r.getUpdatedAt())
+                .build();
+    }
+
+    // --- 생성 ---
+    @Transactional
+    public RecordResponse create(Long userId, RecordCreateRequest req) {
+        problemRepository.findById(req.getProblemId())
+                .filter(p -> p.getUserId().equals(userId))
+                .orElseThrow(() -> new IllegalArgumentException("Problem not found"));
+
+        StudyRecord r = StudyRecord.builder()
+                .userId(userId)
+                .problemId(req.getProblemId())
+                .titleOpt(req.getTitleOpt())
+                .contentMarkdown(req.getContentMarkdown())
+                .build();
+        recordRepository.save(r);
+        return toResponse(r);
+    }
+
+    // --- 단건 조회(소유자 검증) ---
+    @Transactional(readOnly = true)
+    public RecordResponse getOne(Long userId, Long recordId) {
+        StudyRecord r = recordRepository.findByIdAndUserId(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+        return toResponse(r);
+    }
+
+    // --- 타임라인 목록(문제별) ---
+    @Transactional(readOnly = true)
+    public Page<RecordResponse> listByProblem(Long userId, Long problemId, Pageable pageable) {
+        problemRepository.findById(problemId)
+                .filter(p -> p.getUserId().equals(userId))
+                .orElseThrow(() -> new IllegalArgumentException("Problem not found"));
+
+        return recordRepository.findByUserIdAndProblemId(userId, problemId, pageable)
+                .map(this::toResponse);
+    }
+
+    // --- 수정(부분) ---
+    @Transactional
+    public RecordResponse update(Long userId, Long recordId, RecordUpdateRequest req) {
+        StudyRecord r = recordRepository.findByIdAndUserId(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+
+        if (req.getTitleOpt() != null)       r.setTitleOpt(req.getTitleOpt());
+        if (req.getContentMarkdown() != null) r.setContentMarkdown(req.getContentMarkdown());
+
+        return toResponse(r);
+    }
+
+    // --- 삭제 ---
+    @Transactional
+    public void delete(Long userId, Long recordId) {
+        StudyRecord r = recordRepository.findByIdAndUserId(recordId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Record not found"));
+        recordRepository.delete(r);
+    }
+}

--- a/src/main/java/io/reviewcoder/global/auth/CurrentUserProvider.java
+++ b/src/main/java/io/reviewcoder/global/auth/CurrentUserProvider.java
@@ -9,7 +9,7 @@ import java.security.Principal;
 
 @Component
 @RequiredArgsConstructor
-public class CurrentUser {
+public class CurrentUserProvider {
 
     private final UserRepository userRepository;
 


### PR DESCRIPTION
변경사항
AS-IS

TO-BE
학습 기록(StudyRecord) 도메인 추가
엔티티: study_record(record_id, user_id, problem_id, title_opt, content_markdown, created_at, updated_at)
인덱스: (user_id, problem_id), (problem_id, created_at)
API 추가
생성
문제별 타임라인
단건 조회
부분 수정
삭제
검증/정책
RecordCreateRequest: problemId 필수, contentMarkdown 필수(최대 20000), titleOpt 최대 300
RecordUpdateRequest: titleOpt/contentMarkdown 선택(부분 수정), 동일 길이 제한
소유자 검증: 기록 및 문제는 로그인 사용자(userId) 기준으로만 접근 가능
보안/컨텍스트
(이후 강사님이 말씀해주신 피드백 진행 예정)
테스트
 테스트 코드
 API 테스트